### PR TITLE
Adding support for queries for all entities of a particular type, inc…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Example of query for cell by protein
 - Reworking client-side parameter validation
 - Integrating hubmap_cell_id_gen_py into examples
+- Supporting queries for all entities of a particular type, including proteins
 
 0.0.3
 - Change to more fluent SDK: `select_TARGET(where='SOURCE', has='CRITERIA', ...)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Reworking client-side parameter validation
 - Integrating hubmap_cell_id_gen_py into examples
 - Supporting queries for all entities of a particular type, including proteins
+- Expanding table in readme
 
 0.0.3
 - Change to more fluent SDK: `select_TARGET(where='SOURCE', has='CRITERIA', ...)`

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Find cells with different criteria, and intersect resulting sets:
 >>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
 
 >>> [m for m in dir(client) if m.startswith('select_')]
-['select_cells', 'select_clusters', 'select_datasets', 'select_genes', 'select_organs']
+['select_cells', 'select_clusters', 'select_datasets', 'select_genes', 'select_organs', 'select_proteins']
 
 >>> cells_with_vim = client.select_cells(where='gene', has=['VIM > 0.5'], genomic_modality='rna', logical_operator='and')
 >>> assert len(cells_with_vim) > 0

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Find cells with different criteria, and intersect resulting sets:
 >>> [m for m in dir(client) if m.startswith('select_')]
 ['select_cells', 'select_clusters', 'select_datasets', 'select_genes', 'select_organs', 'select_proteins']
 
->>> cells_with_vim = client.select_cells(where='gene', has=['VIM > 0.5'], genomic_modality='rna', logical_operator='and')
+>>> cells_with_vim = client.select_cells(where='gene', has=['VIM > 0.5'], genomic_modality='rna')
 >>> assert len(cells_with_vim) > 0
 
 # Select cells from the datasets with the following UUIDs:
@@ -48,14 +48,14 @@ Find cells with different criteria, and intersect resulting sets:
 
 Only some types of objects can be retrieved from other types of objects:
 
-| `where=...`       | `cell`    | `cluster` | `dataset` | `gene`    | `organ`   | `protein` |
-| ----------------- | --------- | --------- | --------- | --------- | --------- | --------- |
-| [`select_cells()`](https://github.com/hubmapconsortium/hubmap-api-py-client/blob/main/examples/select_cells.md)                                                                                                              | ✓         |           | ✓         | ✓         | ✓         | ✓         |
-| [`select_clusters()`](https://github.com/hubmapconsortium/hubmap-api-py-client/blob/main/examples/select_clusters.md)                                                                                                              |           | ✓         | ✓         | ✓ ✩       | ✩         | ✩         |
-| [`select_datasets()`](https://github.com/hubmapconsortium/hubmap-api-py-client/blob/main/examples/select_datasets.md)| ✓         | ✓         | ✓         |           |✶          |           |
-| [`select_genes()`](https://github.com/hubmapconsortium/hubmap-api-py-client/blob/main/examples/select_genes.md)                                                                                                              |           | ✓ ✩       |           | ✓         | ✓ ✩       | ✩         |
-| [`select_organs()`](https://github.com/hubmapconsortium/hubmap-api-py-client/blob/main/examples/select_organs.md)                                                                                                              | ✓         | ✩         | ✶         | ✓ ✩       | ✓         | ✩         |
-| ~~`select_proteins()`~~                                                                                                          |           | ✩         |           | ✩         | ✩         |           |
+| `where=...`       | None    | `cell`    | `cluster` | `dataset` | `gene`    | `organ`   | `protein` |
+| ----------------- | --------- | --------- | --------- | --------- | --------- | --------- | --------- |
+| [`select_cells()`](https://github.com/hubmapconsortium/hubmap-api-py-client/blob/main/examples/select_cells.md)                                                                                                              | ✓         | ✓         |           | ✓         | ✓         | ✓         | ✓         |
+| [`select_clusters()`](https://github.com/hubmapconsortium/hubmap-api-py-client/blob/main/examples/select_clusters.md)                                                                                                              | ✓         |           | ✓         | ✓         | ✓ ✩       | ✩         | ✩         |
+| [`select_datasets()`](https://github.com/hubmapconsortium/hubmap-api-py-client/blob/main/examples/select_datasets.md)| ✓         | ✓         | ✓         | ✓         |           |✶          |           |
+| [`select_genes()`](https://github.com/hubmapconsortium/hubmap-api-py-client/blob/main/examples/select_genes.md)                                                                                                              | ✓         |           | ✓ ✩       |           | ✓         | ✓ ✩       | ✩         |
+| [`select_organs()`](https://github.com/hubmapconsortium/hubmap-api-py-client/blob/main/examples/select_organs.md)                                                                                                              | ✓         | ✓         | ✩         | ✶         | ✓ ✩       | ✓         | ✩         |
+| [`select_proteins()`](https://github.com/hubmapconsortium/hubmap-api-py-client/blob/main/examples/select_organs.md)                                                                                                          | ✓         |           | ✩         |           | ✩         | ✩         |           |
 
 - "✓" = Supported by Cells API, and this client.
 - "✶" = Supported by Entities API; support in this client is [on the roadmap](https://github.com/hubmapconsortium/hubmap-api-py-client/issues/25).

--- a/examples/error-handling.md
+++ b/examples/error-handling.md
@@ -9,12 +9,12 @@ Traceback (most recent call last):
 ...
 ValueError: Operand output types do not match: gene != cell
 
->>> client.select_cells(where='fake', has=['VIM>1'], genomic_modality='rna', logical_operator='and')
+>>> client.select_cells(where='fake', has=['VIM>1'], genomic_modality='rna')
 Traceback (most recent call last):
 ...
 ValueError: fake not in ['cell', 'gene', 'organ', 'protein', 'dataset']
 
->>> client.select_cells(where='gene', has=['VIM>1'], genomic_modality='fake', logical_operator='and')
+>>> client.select_cells(where='gene', has=['VIM>1'], genomic_modality='fake')
 Traceback (most recent call last):
 ...
 ValueError: fake not in ['rna', 'atac']

--- a/examples/repr.md
+++ b/examples/repr.md
@@ -4,7 +4,7 @@
 >>> client
 <Client base_url=https://cells.dev.hubmapconsortium.org/api/>
 
->>> cells_with_vim = client.select_cells(where='gene', has=['VIM > 0.5'], genomic_modality='rna', logical_operator='and')
+>>> cells_with_vim = client.select_cells(where='gene', has=['VIM > 0.5'], genomic_modality='rna')
 >>> type(cells_with_vim)
 <class 'hubmap_api_py_client.external.CellResultsSet'>
 

--- a/examples/select_cells.md
+++ b/examples/select_cells.md
@@ -1,8 +1,16 @@
-`client.select_cells(where='gene', ...)`:
+`client.select_cells()`:
 ```python
 >>> from hubmap_api_py_client import Client
 >>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
 
+>>> all_cells = client.select_cells()
+>>> assert len(all_cells) > 0
+
+```
+
+
+`client.select_cells(where='gene', ...)`:
+```python
 >>> cells_with_gene = client.select_cells(where='gene', has=['CASTOR2 > 1'], genomic_modality='rna', logical_operator='and')
 >>> assert len(cells_with_gene) > 0
 

--- a/examples/select_cells.md
+++ b/examples/select_cells.md
@@ -11,10 +11,10 @@
 
 `client.select_cells(where='gene', ...)`:
 ```python
->>> cells_with_gene = client.select_cells(where='gene', has=['CASTOR2 > 1'], genomic_modality='rna', logical_operator='and')
+>>> cells_with_gene = client.select_cells(where='gene', has=['CASTOR2 > 1'], genomic_modality='rna')
 >>> assert len(cells_with_gene) > 0
 
->>> cells_with_gene_atac = client.select_cells(where='gene', has=['CHN2'], genomic_modality='atac', logical_operator='and')
+>>> cells_with_gene_atac = client.select_cells(where='gene', has=['CHN2'], genomic_modality='atac')
 >>> assert len(cells_with_gene_atac) > 0
 
 ```

--- a/examples/select_clusters.md
+++ b/examples/select_clusters.md
@@ -1,8 +1,15 @@
-`client.select_clusters(where='gene', ...)`:
+`client.select_clusters()`:
 ```python
 >>> from hubmap_api_py_client import Client
 >>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
 
+>>> all_clusters = client.select_clusters()
+>>> assert len(all_clusters) > 0
+
+```
+
+`client.select_clusters(where='gene', ...)`:
+```python
 >>> clusters_with_gene = client.select_clusters(where='gene', has=['CASTOR2'], genomic_modality='atac', p_value=0.05)
 >>> assert len(clusters_with_gene) > 0
 

--- a/examples/select_datasets.md
+++ b/examples/select_datasets.md
@@ -1,7 +1,14 @@
-`client.select_datasets(where='cell', )`:
+`client.select_datasets()`:
 ```python
 >>> from hubmap_api_py_client import Client
 >>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
+>>> all_datasets = client.select_datasets()
+>>> assert len(all_datasets) > 0
+
+```
+
+`client.select_datasets(where='cell', )`:
+```python
 >>> from hubmap_cell_id_gen_py import get_sequencing_cell_id
 >>> sequencing_cell_id = get_sequencing_cell_id('210d118a14c8624b6bb9610a9062656e','AAACAACGAAACGTGG')
 >>> cell_datasets = client.select_datasets(where='cell', has=[sequencing_cell_id])

--- a/examples/select_genes.md
+++ b/examples/select_genes.md
@@ -1,8 +1,15 @@
-`client.select_genes(where='organ', ...)`:
+`client.select_genes()`:
 ```python
 >>> from hubmap_api_py_client import Client
 >>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
 
+>>> all_genes = client.select_genes()
+>>> assert len(all_genes) > 0
+
+```
+
+`client.select_genes(where='organ', ...)`:
+```python
 >>> kidney_genes = client.select_genes(where='organ', has=['Kidney'], genomic_modality='rna', p_value=0.05)
 >>> kidney_genes[0].keys()
 dict_keys(['gene_symbol', 'go_terms'])

--- a/examples/select_organs.md
+++ b/examples/select_organs.md
@@ -1,8 +1,15 @@
-`client.select_organs(where='gene', ...)`:
+`client.select_organs()`:
 ```python
 >>> from hubmap_api_py_client import Client
 >>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
 
+>>> all_organs = client.select_organs()
+>>> assert len(all_organs) > 0
+
+```
+
+`client.select_organs(where='gene', ...)`:
+```python
 >>> organs_with_gene = client.select_organs(where='gene', has=['CHN2'], genomic_modality='atac', p_value=0.05)
 >>> assert len(organs_with_gene) > 0
 

--- a/examples/select_proteins.md
+++ b/examples/select_proteins.md
@@ -8,3 +8,4 @@
 
 ```
 
+No other protein queries currently supported.

--- a/examples/select_proteins.md
+++ b/examples/select_proteins.md
@@ -1,0 +1,10 @@
+`client.select_proteins()`:
+```python
+>>> from hubmap_api_py_client import Client
+>>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
+
+>>> all_proteins = client.select_proteins()
+>>> assert len(all_proteins) > 0
+
+```
+

--- a/examples/set-operations.md
+++ b/examples/set-operations.md
@@ -29,7 +29,7 @@ Providing a list to `has` is the same as using `|` for the union:
 
 Intersection and difference are also available:
 ```python
->>> vim_cells = client.select_cells(where='gene', has=['VIM > 0.5'], genomic_modality='rna', logical_operator='and')
+>>> vim_cells = client.select_cells(where='gene', has=['VIM > 0.5'], genomic_modality='rna')
 >>> a_b_vim_cells = a_b_cells & vim_cells
 >>> a_b_no_vim_cells = a_b_cells - vim_cells
 >>> assert len(a_b_vim_cells) + len(a_b_no_vim_cells) == len_a_b_cells

--- a/hubmap_api_py_client/external.py
+++ b/hubmap_api_py_client/external.py
@@ -15,7 +15,7 @@ class ExternalClient():
             input_type=None, output_type=None, has=None,
             genomic_modality=None, p_value=None, logical_operator=None,
             ResultsSetSubclass=None):
-        if not isinstance(has, list):
+        if not isinstance(has, list) and input_type is not None:
             raise TypeError(f'"has" parameter must be a list, not {has}')
         handle = self.client.hubmap_query(input_type, output_type, has, genomic_modality,
                                           p_value, logical_operator)
@@ -119,6 +119,6 @@ def _create_subclass(output_type):
     return type(class_name(output_type), (ResultsSet,), {})
 
 
-for output_type in ['cell', 'organ', 'gene', 'cluster', 'dataset']:
+for output_type in ['cell', 'organ', 'gene', 'cluster', 'dataset', 'protein']:
     ResultsSetSubclass = _create_subclass(output_type)
     _add_method(output_type, ResultsSetSubclass)

--- a/hubmap_api_py_client/internal.py
+++ b/hubmap_api_py_client/internal.py
@@ -62,16 +62,15 @@ class InternalClient():
         '''
         This function takes query parameters and returns a query set token.
         '''
+        request_url = self.base_url + output_type + "/"
         if input_type is None:
-            response = requests.get(self.base_url + output_type + "/")
+            response = requests.get(request_url)
         else:
             self._check_parameters(
                 input_type=input_type, output_type=output_type,
                 input_set=input_set, genomic_modality=genomic_modality, p_value=p_value)
-            request_url = self.base_url + output_type + "/"
             request_dict = self._fill_request_dict(
                 input_type, input_set, genomic_modality, p_value, logical_operator)
-
             response = requests.post(request_url, request_dict)
         results = response.json()['results']
         # Returns the key to be used in future computations

--- a/hubmap_api_py_client/internal.py
+++ b/hubmap_api_py_client/internal.py
@@ -14,7 +14,7 @@ class InternalClient():
             self,
             input_type: str, output_type: str, input_set: List[str],
             genomic_modality: str, p_value: float):
-        output_types = ['cell', 'organ', 'gene', 'cluster', 'dataset']
+        output_types = ['cell', 'organ', 'gene', 'cluster', 'dataset', 'protein']
         if output_type not in output_types:
             raise ValueError(f'{output_type} not in {output_types}')
 
@@ -24,7 +24,8 @@ class InternalClient():
             'organ': ['organ', 'cell', 'gene'],
             'gene': ['gene', 'organ', 'cluster'],
             'cluster': ['cluster', 'gene', 'dataset'],
-            'dataset': ['dataset', 'cell', 'cluster']
+            'dataset': ['dataset', 'cell', 'cluster'],
+            'protein': [],  # Only allow queries for all proteins
         }
         if input_type not in input_types[output_type]:
             raise ValueError(f'{input_type} not in {input_types[output_type]}')
@@ -61,14 +62,17 @@ class InternalClient():
         '''
         This function takes query parameters and returns a query set token.
         '''
-        self._check_parameters(
-            input_type=input_type, output_type=output_type,
-            input_set=input_set, genomic_modality=genomic_modality, p_value=p_value)
-        request_url = self.base_url + output_type + "/"
-        request_dict = self._fill_request_dict(
-            input_type, input_set, genomic_modality, p_value, logical_operator)
+        if input_type is None:
+            response = requests.get(self.base_url + output_type + "/")
+        else:
+            self._check_parameters(
+                input_type=input_type, output_type=output_type,
+                input_set=input_set, genomic_modality=genomic_modality, p_value=p_value)
+            request_url = self.base_url + output_type + "/"
+            request_dict = self._fill_request_dict(
+                input_type, input_set, genomic_modality, p_value, logical_operator)
 
-        response = requests.post(request_url, request_dict)
+            response = requests.post(request_url, request_dict)
         results = response.json()['results']
         # Returns the key to be used in future computations
         return results[0][HANDLE]


### PR DESCRIPTION
This PR contains commits to support queries for all entities of a particular type, using a syntax like client.select_cells(), as well as examples for each entity.  Included is the ability to query for all proteins.  However, this is the only type of query for proteins supported by the API at this time.