### PR TITLE
Less client-side checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Integrating hubmap_cell_id_gen_py into examples
 - Supporting queries for all entities of a particular type, including proteins
 - Expanding table in readme
+- Fewer preflight checks on requests: These are a maintenance burden.
 
 0.0.3
 - Change to more fluent SDK: `select_TARGET(where='SOURCE', has='CRITERIA', ...)`

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Find cells with different criteria, and intersect resulting sets:
 >>> cells_with_vim_in_datasets = cells_with_vim & cells_in_datasets
 
 # Get a list; should run quickly:
->>> cell_list = cells_with_vim_in_datasets[0:10]
+>>> cell_list = cells_with_vim_in_datasets.get_list(10)
 >>> assert len(cell_list) == 10
 >>> assert cell_list[0].keys() == {'cell_id', 'modality', 'dataset', 'organ', 'clusters', 'protein_mean', 'protein_total', 'protein_covar'}
 

--- a/examples/differential-expression.md
+++ b/examples/differential-expression.md
@@ -11,9 +11,6 @@ Find genes differentially expressed by the kidney at significance level 0.05:
 
 Find organs that differentially express the gene VIM at the 0.01 significance level
 ```python
->>> from hubmap_api_py_client import Client
->>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
-
 >>> organs_with_vim = client.select_organs(where='gene', has=['VIM'], genomic_modality='rna', p_value=0.01)
 >>> organs_with_vim_details = organs_with_vim.get_details(10)
 >>> assert organs_with_vim_details[0].keys() == {'grouping_name', 'values'}

--- a/examples/error-handling.md
+++ b/examples/error-handling.md
@@ -7,7 +7,7 @@
 >>> kidney_genes & kidney_cells
 Traceback (most recent call last):
 ...
-ValueError: Operand output types do not match: gene != cell
+hubmap_api_py_client.errors.ClientError: Cannot combine queries on two different base models.
 
 >>> client.select_cells(where='fake', has=['VIM>1'], genomic_modality='rna')
 Traceback (most recent call last):

--- a/examples/error-handling.md
+++ b/examples/error-handling.md
@@ -17,7 +17,7 @@ ValueError: fake not in ['cell', 'gene', 'organ', 'protein', 'dataset']
 >>> client.select_cells(where='gene', has=['VIM>1'], genomic_modality='fake')
 Traceback (most recent call last):
 ...
-ValueError: fake not in ['rna', 'atac']
+hubmap_api_py_client.internal.ApiError
 
 ```
 

--- a/examples/error-handling.md
+++ b/examples/error-handling.md
@@ -12,12 +12,12 @@ ValueError: Operand output types do not match: gene != cell
 >>> client.select_cells(where='fake', has=['VIM>1'], genomic_modality='rna')
 Traceback (most recent call last):
 ...
-hubmap_api_py_client.errors.ClientError
+hubmap_api_py_client.errors.ClientError: fake not in ['organ', 'gene', 'dataset', 'cluster', 'protein']
 
 >>> client.select_cells(where='gene', has=['VIM>1'], genomic_modality='fake')
 Traceback (most recent call last):
 ...
-hubmap_api_py_client.errors.ClientError
+hubmap_api_py_client.errors.ClientError: fake not in ['rna', 'atac']
 
 ```
 

--- a/examples/error-handling.md
+++ b/examples/error-handling.md
@@ -12,12 +12,12 @@ ValueError: Operand output types do not match: gene != cell
 >>> client.select_cells(where='fake', has=['VIM>1'], genomic_modality='rna')
 Traceback (most recent call last):
 ...
-ValueError: fake not in ['cell', 'gene', 'organ', 'protein', 'dataset']
+hubmap_api_py_client.errors.ClientError
 
 >>> client.select_cells(where='gene', has=['VIM>1'], genomic_modality='fake')
 Traceback (most recent call last):
 ...
-hubmap_api_py_client.internal.ApiError
+hubmap_api_py_client.errors.ClientError
 
 ```
 

--- a/hubmap_api_py_client/errors.py
+++ b/hubmap_api_py_client/errors.py
@@ -1,0 +1,2 @@
+class ClientError(Exception):
+    pass

--- a/hubmap_api_py_client/external.py
+++ b/hubmap_api_py_client/external.py
@@ -84,20 +84,10 @@ class ResultsSet():
         if isinstance(key, int):
             if key < 0:
                 raise ValueError('Negative index not supported')
-            return self._get_list(1, offset=key)[0]
-        if isinstance(key, slice):
-            if key.step is not None:
-                raise ValueError('Step is not supported')
-            if key.start is None or key.stop is None:
-                raise ValueError('Start and stop are required')
-            if key.start < 0 or key.stop < 0:
-                raise ValueError('Start and stop must be >= 0')
-            if key.stop < key.start:
-                raise ValueError('Stop must be > start')
-            return self._get_list(key.stop - key.start, offset=key.start)
-        raise TypeError()
+            return self.get_list(1, offset=key)[0]
+        raise TypeError('Use get_list for multiple values')
 
-    def _get_list(self, limit, offset=0):
+    def get_list(self, limit, offset=0):
         return self.client.set_list_evaluation(self.handle, self.output_type, limit, offset=offset)
 
     def get_details(

--- a/hubmap_api_py_client/external.py
+++ b/hubmap_api_py_client/external.py
@@ -70,10 +70,6 @@ class ResultsSet():
         return self._operation(other_set, self.client.set_difference)
 
     def _operation(self, other_set, method):
-        if self.output_type != other_set.output_type:
-            raise ValueError(
-                'Operand output types do not match: '
-                f'{self.output_type} != {other_set.output_type}')
         new_handle = method(self.handle, other_set.handle, self.output_type)
         return ResultsSet(
             self.client, new_handle,

--- a/hubmap_api_py_client/internal.py
+++ b/hubmap_api_py_client/internal.py
@@ -98,15 +98,6 @@ class InternalClient():
 
     # These functions take a query set token and return an evaluated query_set:
 
-    def _check_detail_parameters(
-            self, set_type, values_type):
-        type_map = {'cell': ['gene', 'protein'], 'gene': [
-            'organ', 'cluster'], 'cluster': ['gene'], 'organ': ['gene']}
-        allowed_types = type_map[set_type]
-        if values_type not in allowed_types:
-            raise ValueError(
-                f'For "{set_type}", only {allowed_types} allowed, not "{values_type}"')
-
     def set_count(
             self, set_key: str, set_type: str) -> str:
         request_url = self.base_url + "count/"
@@ -137,7 +128,6 @@ class InternalClient():
         containing data specified in include_values
         It may be slow.
         '''
-        self._check_detail_parameters(set_type, values_type)
         request_url = self.base_url + set_type + "detailevaluation/"
         request_dict = {"key": set_key, "set_type": set_type, "limit": limit, "offset": offset,
                         "values_included": values_included, "sort_by": sort_by,

--- a/hubmap_api_py_client/internal.py
+++ b/hubmap_api_py_client/internal.py
@@ -104,12 +104,12 @@ class InternalClient():
         # It might be a GET that produced the response, so not ready to combine these.
         response_json = response.json()
         if 'results' not in response_json:
-            raise ClientError()
+            raise ClientError(response_json['message'])
         return response_json['results'][0][HANDLE]
 
     def _post_and_get_results(self, url, request_dict):
         response = requests.post(url, request_dict)
         response_json = response.json()
         if 'results' not in response_json:
-            raise ClientError()
+            raise ClientError(response_json['message'])
         return response_json['results']


### PR DESCRIPTION
@SFD5311 : Now that there are error responses from the API, this removes most of the client-side pre-flight checks. They were going to be a significant maintenance burden, for relatively little gain. I also removed the subscript access magic method: It had too many special cases, and I thought it would be more likely to cause confusion than to actually making things easier.

On error responses, in addition to the stack trace, could you include a message field? That would be something that could be used in production and dev, and that I could add to the doctests.

One additional simplification to consider: Could the one GET endpoint url also support POST? That would let us take out one more if-then, and give the users one less thing to trip over.

cc: @john-conroy: This should make the JS translation less kludgy.