### PR TITLE
Move test url into package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 0.0.6 - in progress
+- Move the test endpoint URL into the package, to simplify testing against other endpoints.
 
 0.0.5 - 2021-02-06
 - Support queries for and by dataset

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ pip install hubmap-api-py-client
 
 Find cells with different criteria, and intersect resulting sets:
 ```python
->>> from hubmap_api_py_client import Client
->>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
+>>> from hubmap_api_py_client import Client, test_url
+>>> client = Client(test_url)
 
 >>> [m for m in dir(client) if m.startswith('select_')]
 ['select_cells', 'select_clusters', 'select_datasets', 'select_genes', 'select_organs', 'select_proteins']

--- a/examples/differential-expression.md
+++ b/examples/differential-expression.md
@@ -1,7 +1,7 @@
 Find genes differentially expressed by the kidney at significance level 0.05:
 ```python
->>> from hubmap_api_py_client import Client
->>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
+>>> from hubmap_api_py_client import Client, test_url
+>>> client = Client(test_url)
 
 >>> kidney_genes = client.select_genes(where='organ', has=['Kidney'], genomic_modality='rna', p_value=0.05)
 >>> kidney_genes_details = kidney_genes.get_details(10)

--- a/examples/error-handling.md
+++ b/examples/error-handling.md
@@ -1,6 +1,6 @@
 ```python
->>> from hubmap_api_py_client import Client
->>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
+>>> from hubmap_api_py_client import Client, test_url
+>>> client = Client(test_url)
 
 >>> kidney_genes = client.select_genes(where='organ', has=['Kidney'], genomic_modality='rna', p_value=0.05)
 >>> kidney_cells = client.select_cells(where='organ', has=['Kidney'])

--- a/examples/repr.md
+++ b/examples/repr.md
@@ -1,6 +1,6 @@
 ```python
->>> from hubmap_api_py_client import Client
->>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
+>>> from hubmap_api_py_client import Client, test_url
+>>> client = Client(test_url)
 >>> client
 <Client base_url=https://cells.dev.hubmapconsortium.org/api/>
 

--- a/examples/select_cells.md
+++ b/examples/select_cells.md
@@ -1,7 +1,7 @@
 `client.select_cells()`:
 ```python
->>> from hubmap_api_py_client import Client
->>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
+>>> from hubmap_api_py_client import Client, test_url
+>>> client = Client(test_url)
 
 >>> all_cells = client.select_cells()
 >>> assert len(all_cells) > 0

--- a/examples/select_clusters.md
+++ b/examples/select_clusters.md
@@ -1,7 +1,7 @@
 `client.select_clusters()`:
 ```python
->>> from hubmap_api_py_client import Client
->>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
+>>> from hubmap_api_py_client import Client, test_url
+>>> client = Client(test_url)
 
 >>> all_clusters = client.select_clusters()
 >>> assert len(all_clusters) > 0

--- a/examples/select_datasets.md
+++ b/examples/select_datasets.md
@@ -1,7 +1,7 @@
 `client.select_datasets()`:
 ```python
->>> from hubmap_api_py_client import Client
->>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
+>>> from hubmap_api_py_client import Client, test_url
+>>> client = Client(test_url)
 >>> all_datasets = client.select_datasets()
 >>> assert len(all_datasets) > 0
 

--- a/examples/select_genes.md
+++ b/examples/select_genes.md
@@ -1,7 +1,7 @@
 `client.select_genes()`:
 ```python
->>> from hubmap_api_py_client import Client
->>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
+>>> from hubmap_api_py_client import Client, test_url
+>>> client = Client(test_url)
 
 >>> all_genes = client.select_genes()
 >>> assert len(all_genes) > 0

--- a/examples/select_organs.md
+++ b/examples/select_organs.md
@@ -1,7 +1,7 @@
 `client.select_organs()`:
 ```python
->>> from hubmap_api_py_client import Client
->>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
+>>> from hubmap_api_py_client import Client, test_url
+>>> client = Client(test_url)
 
 >>> all_organs = client.select_organs()
 >>> assert len(all_organs) > 0

--- a/examples/select_proteins.md
+++ b/examples/select_proteins.md
@@ -1,7 +1,7 @@
 `client.select_proteins()`:
 ```python
->>> from hubmap_api_py_client import Client
->>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
+>>> from hubmap_api_py_client import Client, test_url
+>>> client = Client(test_url)
 
 >>> all_proteins = client.select_proteins()
 >>> assert len(all_proteins) > 0

--- a/examples/set-operations.md
+++ b/examples/set-operations.md
@@ -1,7 +1,7 @@
 Providing a list to `has` is the same as using `|` for the union:
 ```python
->>> from hubmap_api_py_client import Client
->>> client = Client('https://cells.dev.hubmapconsortium.org/api/')
+>>> from hubmap_api_py_client import Client, test_url
+>>> client = Client(test_url)
 
 >>> a_uuid = '68159e4bd6a2cea1cd66e8f3050cfcb7'
 >>> b_uuid = 'e8d642084fc5ec8b5d348ebab96a4b22'

--- a/hubmap_api_py_client/__init__.py
+++ b/hubmap_api_py_client/__init__.py
@@ -1,1 +1,4 @@
 from hubmap_api_py_client.external import ExternalClient as Client  # noqa: F401
+
+# This could be moved to a git-ignored config, if that would be useful.
+test_url = 'https://cells.dev.hubmapconsortium.org/api/'

--- a/hubmap_api_py_client/internal.py
+++ b/hubmap_api_py_client/internal.py
@@ -9,7 +9,6 @@ HANDLE = 'query_handle'
 
 class InternalClient():
     def __init__(self, base_url):
-        # 'https://cells.dev.hubmapconsortium.org/api/'
         self.base_url = base_url
 
     def _fill_request_dict(


### PR DESCRIPTION
@SFD5311 : Would this be a useful change on your end? The idea is to make it simpler to point the test suite at another instance you might have running locally. Longer term, this should be in a config, instead of baking it into the package, but does having it in just one place make things easier for you?