### PR TITLE
Remove unused `values_included` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.0.6 - in progress
 - Move the test endpoint URL into the package, to simplify testing against other endpoints.
 - Only use POST, for simplicity.
+- Remove unused `values_included`.
 
 0.0.5 - 2021-02-06
 - Support queries for and by dataset

--- a/hubmap_api_py_client/external.py
+++ b/hubmap_api_py_client/external.py
@@ -86,9 +86,7 @@ class ResultsSet():
     def get_list(self, limit, offset=0):
         return self.client.set_list_evaluation(self.handle, self.output_type, limit, offset=offset)
 
-    def get_details(
-            self, limit, offset=0,
-            values_included=[], sort_by=None):
+    def get_details(self, limit, offset=0, sort_by=None):
         return self.client.set_detail_evaluation(
             self.handle, self.output_type, limit,
             offset=offset,


### PR DESCRIPTION
@SFD5311 : I think this parameter is vestigial... or at least it's not being used now, but maybe it should be?

If it should be referenced in the code, could you come up with a new doctest that fails now, but would be fixed by this change?:
```diff
- values_included=[self.query]
+ values_included=values_included
```

On the other hand: If this PR is good, I think my next step would be to make `sort_by` a setter method on the object, and then bring back the magic method: If there is no `sort`, then `get_list` runs ... if there is a `sort`, `get_details` runs. 

Thoughts?