### PR TITLE
Mccalluc/really fix values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 0.0.6 - in progress
 - Move the test endpoint URL into the package, to simplify testing against other endpoints.
 - Only use POST, for simplicity.
+- Use values_included appropriately.
 
 0.0.5 - 2021-02-06
 - Support queries for and by dataset

--- a/examples/select_cells.md
+++ b/examples/select_cells.md
@@ -20,13 +20,8 @@ dict_keys([])
 
 >>> cells_with_gene_details_with_values = cells_with_gene.get_details(10, values_included=['CASTOR2'])
 >>> cells_with_gene_details_with_values[0]['values'].keys()
-dict_keys([]) 
+dict_keys(['CASTOR2'])
 
-```
-
-That isn't right: It should get `'CASTOR2'`.
-
-```
 >>> cells_with_gene_atac = client.select_cells(where='gene', has=['CHN2'], genomic_modality='atac')
 >>> assert len(cells_with_gene_atac) > 0
 

--- a/examples/select_cells.md
+++ b/examples/select_cells.md
@@ -20,8 +20,13 @@ dict_keys([])
 
 >>> cells_with_gene_details_with_values = cells_with_gene.get_details(10, values_included=['CASTOR2'])
 >>> cells_with_gene_details_with_values[0]['values'].keys()
-dict_keys(['CASTOR2'])
+dict_keys([]) 
 
+```
+
+That isn't right: It should get `'CASTOR2'`.
+
+```
 >>> cells_with_gene_atac = client.select_cells(where='gene', has=['CHN2'], genomic_modality='atac')
 >>> assert len(cells_with_gene_atac) > 0
 

--- a/examples/select_cells.md
+++ b/examples/select_cells.md
@@ -14,6 +14,14 @@
 >>> cells_with_gene = client.select_cells(where='gene', has=['CASTOR2 > 1'], genomic_modality='rna')
 >>> assert len(cells_with_gene) > 0
 
+>>> cells_with_gene_details = cells_with_gene.get_details(10)
+>>> cells_with_gene_details[0]['values'].keys()
+dict_keys([])
+
+>>> cells_with_gene_details_with_values = cells_with_gene.get_details(10, values_included=['CASTOR2'])
+>>> cells_with_gene_details_with_values[0]['values'].keys()
+dict_keys(['CASTOR2'])
+
 >>> cells_with_gene_atac = client.select_cells(where='gene', has=['CHN2'], genomic_modality='atac')
 >>> assert len(cells_with_gene_atac) > 0
 
@@ -30,6 +38,14 @@
 ```python
 >>> ki67_cells = client.select_cells(where='protein', has=['Ki67>5000'])
 >>> assert len(ki67_cells) > 0
+
+>>> ki67_cells_details = ki67_cells.get_details(10)
+>>> ki67_cells_details[0]['values'].keys()
+dict_keys([])
+
+>>> ki67_cells_details_with_values = ki67_cells.get_details(10, values_included=['Ki67', 'CD20'])
+>>> ki67_cells_details_with_values[0]['values'].keys()
+dict_keys(['CD20', 'Ki67'])
 
 ```
 

--- a/examples/select_clusters.md
+++ b/examples/select_clusters.md
@@ -19,6 +19,9 @@ dict_keys(['cluster_method', 'cluster_data', 'grouping_name', 'dataset'])
 >>> clusters_with_gene.get_details(1)[0].keys()
 dict_keys(['cluster_method', 'cluster_data', 'grouping_name', 'dataset', 'values'])
 
+>>> clusters_with_gene.get_details(1, values_included=['CASTOR2'])[0]['values'].keys()
+dict_keys(['CASTOR2'])
+
 ```
 
 `client.select_clusters(where='dataset', ...)`:

--- a/examples/select_genes.md
+++ b/examples/select_genes.md
@@ -21,6 +21,13 @@ dict_keys(['gene_symbol', 'go_terms', 'values'])
 >>> kidney_genes_details[0]['values'].keys()
 dict_keys([])
 
+>>> kidney_genes_details_with_values = kidney_genes.get_details(10, values_included=['Kidney'])
+>>> kidney_genes_details_with_values[0].keys()
+dict_keys(['gene_symbol', 'go_terms', 'values'])
+
+>>> kidney_genes_details_with_values[0]['values'].keys()
+dict_keys(['Kidney'])
+
 ```
 
 `client.select_genes(where='cluster', ...)`:

--- a/examples/select_genes.md
+++ b/examples/select_genes.md
@@ -19,7 +19,7 @@ dict_keys(['gene_symbol', 'go_terms'])
 dict_keys(['gene_symbol', 'go_terms', 'values'])
 
 >>> kidney_genes_details[0]['values'].keys()
-dict_keys(['Kidney'])
+dict_keys([])
 
 ```
 

--- a/examples/select_organs.md
+++ b/examples/select_organs.md
@@ -13,6 +13,9 @@
 >>> organs_with_gene = client.select_organs(where='gene', has=['CHN2'], genomic_modality='atac', p_value=0.05)
 >>> assert len(organs_with_gene) > 0
 
+>>> organs_with_gene.get_details(1, values_included=['CASTOR2'])[0]['values'].keys()
+dict_keys(['CASTOR2'])
+
 ```
 
 `client.select_organs(where='cell', ...)`:

--- a/hubmap_api_py_client/external.py
+++ b/hubmap_api_py_client/external.py
@@ -94,7 +94,7 @@ class ResultsSet():
             offset=offset,
             sort_by=sort_by,
             values_type=self.input_type,
-            values_included=[self.query])
+            values_included=values_included)
 
 
 def class_name(output_type):


### PR DESCRIPTION
This PR uses `values_included` the right way... but since there was only that one test that needed to be changed, I feel like our test coverage here is insufficient, but I'm also not sure what kind of values make sense to give for that parameter.

Maybe merge this as is? Or if you want to expand the tests, feel free to commit to this branch.

```python
>>> from hubmap_api_py_client import Client, test_url
>>> client = Client(test_url)
>>> kidney_genes = client.select_genes(where='organ', has=['Kidney'], genomic_modality='rna', p_value=0.05)
>>> kidney_genes_details = kidney_genes.get_details(10)
>>> kidney_genes_details
[{'gene_symbol': 'ZNF844-1', 'go_terms': None, 'values': {}}, {'gene_symbol': 'AC025283.2', 'go_terms': None, 'values': {}}, {'gene_symbol': 'CHN2', 'go_terms': None, 'values': {}}, {'gene_symbol': 'AL358113.1', 'go_terms': None, 'values': {}}, {'gene_symbol': 'AL049629.2', 'go_terms': None, 'values': {}}, {'gene_symbol': 'ZNF670', 'go_terms': None, 'values': {}}, {'gene_symbol': 'HYDIN2', 'go_terms': None, 'values': {}}, {'gene_symbol': 'FRG1HP', 'go_terms': None, 'values': {}}, {'gene_symbol': 'CASTOR2', 'go_terms': None, 'values': {}}, {'gene_symbol': 'AL359736.1', 'go_terms': None, 'values': {}}]
>>> kidney_genes_details_w_values = kidney_genes.get_details(10, values_included=['Kidney'])
>>> kidney_genes_details_w_values
[{'gene_symbol': 'ZNF844-1', 'go_terms': None, 'values': {'Kidney': 4.867122023774583e-285}}, {'gene_symbol': 'AC025283.2', 'go_terms': None, 'values': {'Kidney': 0.0}}, {'gene_symbol': 'CHN2', 'go_terms': None, 'values': {'Kidney': 3.532389020219742e-08}}, {'gene_symbol': 'AL358113.1', 'go_terms': None, 'values': {'Kidney': 0.0}}, {'gene_symbol': 'AL049629.2', 'go_terms': None, 'values': {'Kidney': 0.0}}, {'gene_symbol': 'ZNF670', 'go_terms': None, 'values': {'Kidney': 1.3948972972658453e-68}}, {'gene_symbol': 'HYDIN2', 'go_terms': None, 'values': {'Kidney': 0.0}}, {'gene_symbol': 'FRG1HP', 'go_terms': None, 'values': {'Kidney': 0.0}}, {'gene_symbol': 'CASTOR2', 'go_terms': None, 'values': {'Kidney': 4.467999869928024e-24}}, {'gene_symbol': 'AL359736.1', 'go_terms': None, 'values': {'Kidney': 0.0}}]
```