### PR TITLE
Remove get_list from external interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Only use POST, for simplicity.
 - Use values_included appropriately.
 - Values in error are sorted.
+- Remove `get_list` from external interface.
 
 0.0.5 - 2021-02-06
 - Support queries for and by dataset

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Find cells with different criteria, and intersect resulting sets:
 >>> cells_with_vim_in_datasets = cells_with_vim & cells_in_datasets
 
 # Get a list; should run quickly:
->>> cell_list = cells_with_vim_in_datasets.get_details(10)
+>>> cell_list = cells_with_vim_in_datasets.get_list(10)
 >>> assert len(cell_list) == 10
 >>> assert cell_list[0].keys() == {'cell_id', 'modality', 'dataset', 'organ', 'clusters', 'protein_mean', 'protein_total', 'protein_covar'}
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Find cells with different criteria, and intersect resulting sets:
 >>> cells_with_vim_in_datasets = cells_with_vim & cells_in_datasets
 
 # Get a list; should run quickly:
->>> cell_list = cells_with_vim_in_datasets.get_list(10)
+>>> cell_list = cells_with_vim_in_datasets.get_details(10)
 >>> assert len(cell_list) == 10
 >>> assert cell_list[0].keys() == {'cell_id', 'modality', 'dataset', 'organ', 'clusters', 'protein_mean', 'protein_total', 'protein_covar'}
 

--- a/examples/differential-expression.md
+++ b/examples/differential-expression.md
@@ -5,7 +5,8 @@ Find genes differentially expressed by the kidney at significance level 0.05:
 
 >>> kidney_genes = client.select_genes(where='organ', has=['Kidney'], genomic_modality='rna', p_value=0.05)
 >>> kidney_genes_details = kidney_genes.get_details(10)
->>> assert kidney_genes_details[0].keys() == {'gene_symbol', 'go_terms', 'values'}
+>>> kidney_genes_details[0].keys()
+dict_keys(['gene_symbol', 'go_terms'])
 
 ```
 
@@ -13,6 +14,7 @@ Find organs that differentially express the gene VIM at the 0.01 significance le
 ```python
 >>> organs_with_vim = client.select_organs(where='gene', has=['VIM'], genomic_modality='rna', p_value=0.01)
 >>> organs_with_vim_details = organs_with_vim.get_details(10)
->>> assert organs_with_vim_details[0].keys() == {'grouping_name', 'values'}
+>>> organs_with_vim_details[0].keys()
+dict_keys(['grouping_name'])
 
 ```

--- a/examples/differential-expression.md
+++ b/examples/differential-expression.md
@@ -4,7 +4,7 @@ Find genes differentially expressed by the kidney at significance level 0.05:
 >>> client = Client(test_url)
 
 >>> kidney_genes = client.select_genes(where='organ', has=['Kidney'], genomic_modality='rna', p_value=0.05)
->>> kidney_genes_details = kidney_genes.get_details(10)
+>>> kidney_genes_details = kidney_genes.get_list(10)
 >>> kidney_genes_details[0].keys()
 dict_keys(['gene_symbol', 'go_terms'])
 
@@ -13,7 +13,7 @@ dict_keys(['gene_symbol', 'go_terms'])
 Find organs that differentially express the gene VIM at the 0.01 significance level
 ```python
 >>> organs_with_vim = client.select_organs(where='gene', has=['VIM'], genomic_modality='rna', p_value=0.01)
->>> organs_with_vim_details = organs_with_vim.get_details(10)
+>>> organs_with_vim_details = organs_with_vim.get_list(10)
 >>> organs_with_vim_details[0].keys()
 dict_keys(['grouping_name'])
 

--- a/examples/select_cells.md
+++ b/examples/select_cells.md
@@ -14,10 +14,6 @@
 >>> cells_with_gene = client.select_cells(where='gene', has=['CASTOR2 > 1'], genomic_modality='rna')
 >>> assert len(cells_with_gene) > 0
 
->>> cells_with_gene_details = cells_with_gene.get_details(10)
->>> cells_with_gene_details[0]['values'].keys()
-dict_keys([])
-
 >>> cells_with_gene_details_with_values = cells_with_gene.get_details(10, values_included=['CASTOR2'])
 >>> cells_with_gene_details_with_values[0]['values'].keys()
 dict_keys(['CASTOR2'])
@@ -38,10 +34,6 @@ dict_keys(['CASTOR2'])
 ```python
 >>> ki67_cells = client.select_cells(where='protein', has=['Ki67>5000'])
 >>> assert len(ki67_cells) > 0
-
->>> ki67_cells_details = ki67_cells.get_details(10)
->>> ki67_cells_details[0]['values'].keys()
-dict_keys([])
 
 >>> ki67_cells_details_with_values = ki67_cells.get_details(10, values_included=['Ki67', 'CD20'])
 >>> ki67_cells_details_with_values[0]['values'].keys()

--- a/examples/select_cells.md
+++ b/examples/select_cells.md
@@ -14,7 +14,7 @@
 >>> cells_with_gene = client.select_cells(where='gene', has=['CASTOR2 > 1'], genomic_modality='rna')
 >>> assert len(cells_with_gene) > 0
 
->>> cells_with_gene_details_with_values = cells_with_gene.get_details(10, values_included=['CASTOR2'])
+>>> cells_with_gene_details_with_values = cells_with_gene.get_list(10, values_included=['CASTOR2'])
 >>> cells_with_gene_details_with_values[0]['values'].keys()
 dict_keys(['CASTOR2'])
 
@@ -35,7 +35,7 @@ dict_keys(['CASTOR2'])
 >>> ki67_cells = client.select_cells(where='protein', has=['Ki67>5000'])
 >>> assert len(ki67_cells) > 0
 
->>> ki67_cells_details_with_values = ki67_cells.get_details(10, values_included=['Ki67', 'CD20'])
+>>> ki67_cells_details_with_values = ki67_cells.get_list(10, values_included=['Ki67', 'CD20'])
 >>> ki67_cells_details_with_values[0]['values'].keys()
 dict_keys(['CD20', 'Ki67'])
 

--- a/examples/select_clusters.md
+++ b/examples/select_clusters.md
@@ -16,10 +16,10 @@
 >>> clusters_with_gene[0].keys()
 dict_keys(['cluster_method', 'cluster_data', 'grouping_name', 'dataset'])
 
->>> clusters_with_gene.get_details(1)[0].keys()
+>>> clusters_with_gene.get_list(1)[0].keys()
 dict_keys(['cluster_method', 'cluster_data', 'grouping_name', 'dataset'])
 
->>> clusters_with_gene.get_details(1, values_included=['CASTOR2'])[0]['values'].keys()
+>>> clusters_with_gene.get_list(1, values_included=['CASTOR2'])[0]['values'].keys()
 dict_keys(['CASTOR2'])
 
 ```

--- a/examples/select_clusters.md
+++ b/examples/select_clusters.md
@@ -17,7 +17,7 @@
 dict_keys(['cluster_method', 'cluster_data', 'grouping_name', 'dataset'])
 
 >>> clusters_with_gene.get_details(1)[0].keys()
-dict_keys(['cluster_method', 'cluster_data', 'grouping_name', 'dataset', 'values'])
+dict_keys(['cluster_method', 'cluster_data', 'grouping_name', 'dataset'])
 
 >>> clusters_with_gene.get_details(1, values_included=['CASTOR2'])[0]['values'].keys()
 dict_keys(['CASTOR2'])

--- a/examples/select_genes.md
+++ b/examples/select_genes.md
@@ -14,11 +14,11 @@
 >>> kidney_genes[0].keys()
 dict_keys(['gene_symbol', 'go_terms'])
 
->>> kidney_genes_details = kidney_genes.get_details(10)
+>>> kidney_genes_details = kidney_genes.get_list(10)
 >>> kidney_genes_details[0].keys()
 dict_keys(['gene_symbol', 'go_terms'])
 
->>> kidney_genes_details_with_values = kidney_genes.get_details(10, values_included=['Kidney'])
+>>> kidney_genes_details_with_values = kidney_genes.get_list(10, values_included=['Kidney'])
 >>> kidney_genes_details_with_values[0].keys()
 dict_keys(['gene_symbol', 'go_terms', 'values'])
 

--- a/examples/select_genes.md
+++ b/examples/select_genes.md
@@ -16,10 +16,7 @@ dict_keys(['gene_symbol', 'go_terms'])
 
 >>> kidney_genes_details = kidney_genes.get_details(10)
 >>> kidney_genes_details[0].keys()
-dict_keys(['gene_symbol', 'go_terms', 'values'])
-
->>> kidney_genes_details[0]['values'].keys()
-dict_keys([])
+dict_keys(['gene_symbol', 'go_terms'])
 
 >>> kidney_genes_details_with_values = kidney_genes.get_details(10, values_included=['Kidney'])
 >>> kidney_genes_details_with_values[0].keys()

--- a/examples/select_organs.md
+++ b/examples/select_organs.md
@@ -13,7 +13,7 @@
 >>> organs_with_gene = client.select_organs(where='gene', has=['CHN2'], genomic_modality='atac', p_value=0.05)
 >>> assert len(organs_with_gene) > 0
 
->>> organs_with_gene.get_details(1, values_included=['CASTOR2'])[0]['values'].keys()
+>>> organs_with_gene.get_list(1, values_included=['CASTOR2'])[0]['values'].keys()
 dict_keys(['CASTOR2'])
 
 ```

--- a/hubmap_api_py_client/external.py
+++ b/hubmap_api_py_client/external.py
@@ -80,10 +80,10 @@ class ResultsSet():
         if isinstance(key, int):
             if key < 0:
                 raise ValueError('Negative index not supported')
-            return self.get_details(1, offset=key)[0]
-        raise TypeError('Use get_details for multiple values')
+            return self.get_list(1, offset=key)[0]
+        raise TypeError('Use get_list for multiple values')
 
-    def get_details(
+    def get_list(
             self, limit, offset=0,
             values_included=[], sort_by=None):
         if not values_included and not sort_by:

--- a/hubmap_api_py_client/external.py
+++ b/hubmap_api_py_client/external.py
@@ -80,15 +80,16 @@ class ResultsSet():
         if isinstance(key, int):
             if key < 0:
                 raise ValueError('Negative index not supported')
-            return self.get_list(1, offset=key)[0]
-        raise TypeError('Use get_list for multiple values')
-
-    def get_list(self, limit, offset=0):
-        return self.client.set_list_evaluation(self.handle, self.output_type, limit, offset=offset)
+            return self.get_details(1, offset=key)[0]
+        raise TypeError('Use get_details for multiple values')
 
     def get_details(
             self, limit, offset=0,
             values_included=[], sort_by=None):
+        if not values_included and not sort_by:
+            return self.client.set_list_evaluation(
+                self.handle, self.output_type, limit,
+                offset=offset)
         return self.client.set_detail_evaluation(
             self.handle, self.output_type, limit,
             offset=offset,


### PR DESCRIPTION
I think I had just started this when we ran into all the problems with inconsistent results. The idea is that whether to call get_list or get_details will be determined by whether fields or sort is specified, and not something the user needs to worry about.

If this is good, after merging, I'll think about bringing back the `[]` magic methods.