### PR TITLE
Distinguish ResultsSet from ResultsList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Use values_included appropriately.
 - Values in error are sorted.
 - Remove `get_list` from external interface.
+- Distinguish `ResultsSet` from `ResultsList`.
 
 0.0.5 - 2021-02-06
 - Support queries for and by dataset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Values in error are sorted.
 - Remove `get_list` from external interface.
 - Distinguish `ResultsSet` from `ResultsList`.
+- Remove `values_type` parameter
 
 0.0.5 - 2021-02-06
 - Support queries for and by dataset

--- a/README.md
+++ b/README.md
@@ -36,11 +36,14 @@ Find cells with different criteria, and intersect resulting sets:
 
 # Combine criteria with intersection:
 >>> cells_with_vim_in_datasets = cells_with_vim & cells_in_datasets
+>>> assert len(cells_with_vim_in_datasets) > 10
 
 # Get a list; should run quickly:
->>> cell_list = cells_with_vim_in_datasets.get_list(10)
->>> assert len(cell_list) == 10
->>> assert cell_list[0].keys() == {'cell_id', 'modality', 'dataset', 'organ', 'clusters', 'protein_mean', 'protein_total', 'protein_covar'}
+>>> cell_list = cells_with_vim_in_datasets.get_list()
+
+>>> cells = cell_list.get()
+>>> assert len(cells) == 10
+>>> assert cells[0].keys() == {'cell_id', 'modality', 'dataset', 'organ', 'clusters', 'protein_mean', 'protein_total', 'protein_covar'}
 
 ```
 

--- a/examples/differential-expression.md
+++ b/examples/differential-expression.md
@@ -4,7 +4,7 @@ Find genes differentially expressed by the kidney at significance level 0.05:
 >>> client = Client(test_url)
 
 >>> kidney_genes = client.select_genes(where='organ', has=['Kidney'], genomic_modality='rna', p_value=0.05)
->>> kidney_genes_details = kidney_genes.get_list(10)
+>>> kidney_genes_details = kidney_genes.get_list().get()
 >>> kidney_genes_details[0].keys()
 dict_keys(['gene_symbol', 'go_terms'])
 
@@ -13,7 +13,7 @@ dict_keys(['gene_symbol', 'go_terms'])
 Find organs that differentially express the gene VIM at the 0.01 significance level
 ```python
 >>> organs_with_vim = client.select_organs(where='gene', has=['VIM'], genomic_modality='rna', p_value=0.01)
->>> organs_with_vim_details = organs_with_vim.get_list(10)
+>>> organs_with_vim_details = organs_with_vim.get_list().get()
 >>> organs_with_vim_details[0].keys()
 dict_keys(['grouping_name'])
 

--- a/examples/repr.md
+++ b/examples/repr.md
@@ -1,15 +1,25 @@
 ```python
+>>> import re
+>>> def abbreviate(s):
+...     return re.sub(r'=[^ >]+', '=...', str(s))
+
 >>> from hubmap_api_py_client import Client, test_url
 >>> client = Client(test_url)
 >>> client
 <Client base_url=https://cells.dev.hubmapconsortium.org/api/>
 
->>> cells_with_vim = client.select_cells(where='gene', has=['VIM > 0.5'], genomic_modality='rna')
->>> type(cells_with_vim)
+>>> cells_set = client.select_cells(where='gene', has=['VIM > 0.5'], genomic_modality='rna')
+>>> type(cells_set)
 <class 'hubmap_api_py_client.external.CellResultsSet'>
 
->>> import re
->>> re.sub(r'=[^ >]+', '=...', str(cells_with_vim))
+>>> abbreviate(cells_set)
 '<CellResultsSet base_url=... handle=...>'
+
+>>> cells_list = cells_set.get_list()
+>>> type(cells_list)
+<class 'hubmap_api_py_client.external.ResultsList'>
+
+>>> abbreviate(cells_list)
+'<ResultsList base_url=... handle=... values_included=... sort_by=...>'
 
 ```

--- a/examples/select_cells.md
+++ b/examples/select_cells.md
@@ -14,7 +14,7 @@
 >>> cells_with_gene = client.select_cells(where='gene', has=['CASTOR2 > 1'], genomic_modality='rna')
 >>> assert len(cells_with_gene) > 0
 
->>> cells_with_gene_details_with_values = cells_with_gene.get_list(10, values_included=['CASTOR2'])
+>>> cells_with_gene_details_with_values = cells_with_gene.get_list(values_included=['CASTOR2']).get()
 >>> cells_with_gene_details_with_values[0]['values'].keys()
 dict_keys(['CASTOR2'])
 
@@ -35,7 +35,7 @@ dict_keys(['CASTOR2'])
 >>> ki67_cells = client.select_cells(where='protein', has=['Ki67>5000'])
 >>> assert len(ki67_cells) > 0
 
->>> ki67_cells_details_with_values = ki67_cells.get_list(10, values_included=['Ki67', 'CD20'])
+>>> ki67_cells_details_with_values = ki67_cells.get_list(values_included=['Ki67', 'CD20']).get()
 >>> ki67_cells_details_with_values[0]['values'].keys()
 dict_keys(['CD20', 'Ki67'])
 

--- a/examples/select_clusters.md
+++ b/examples/select_clusters.md
@@ -10,16 +10,13 @@
 
 `client.select_clusters(where='gene', ...)`:
 ```python
->>> clusters_with_gene = client.select_clusters(where='gene', has=['CASTOR2'], genomic_modality='atac', p_value=0.05)
->>> assert len(clusters_with_gene) > 0
+>>> clusters_with_gene_set = client.select_clusters(where='gene', has=['CASTOR2'], genomic_modality='atac', p_value=0.05)
+>>> assert len(clusters_with_gene_set) > 0
 
->>> clusters_with_gene[0].keys()
+>>> clusters_with_gene_set.get_list().get()[0].keys()
 dict_keys(['cluster_method', 'cluster_data', 'grouping_name', 'dataset'])
 
->>> clusters_with_gene.get_list(1)[0].keys()
-dict_keys(['cluster_method', 'cluster_data', 'grouping_name', 'dataset'])
-
->>> clusters_with_gene.get_list(1, values_included=['CASTOR2'])[0]['values'].keys()
+>>> clusters_with_gene_set.get_list(values_included=['CASTOR2']).get()[0]['values'].keys()
 dict_keys(['CASTOR2'])
 
 ```

--- a/examples/select_genes.md
+++ b/examples/select_genes.md
@@ -11,18 +11,16 @@
 `client.select_genes(where='organ', ...)`:
 ```python
 >>> kidney_genes = client.select_genes(where='organ', has=['Kidney'], genomic_modality='rna', p_value=0.05)
->>> kidney_genes[0].keys()
+
+>>> kidney_genes_details = kidney_genes.get_list()
+>>> kidney_genes_details.get()[0].keys()
 dict_keys(['gene_symbol', 'go_terms'])
 
->>> kidney_genes_details = kidney_genes.get_list(10)
->>> kidney_genes_details[0].keys()
-dict_keys(['gene_symbol', 'go_terms'])
-
->>> kidney_genes_details_with_values = kidney_genes.get_list(10, values_included=['Kidney'])
->>> kidney_genes_details_with_values[0].keys()
+>>> kidney_genes_details_with_values = kidney_genes.get_list(values_included=['Kidney'])
+>>> kidney_genes_details_with_values.get()[0].keys()
 dict_keys(['gene_symbol', 'go_terms', 'values'])
 
->>> kidney_genes_details_with_values[0]['values'].keys()
+>>> kidney_genes_details_with_values.get()[0]['values'].keys()
 dict_keys(['Kidney'])
 
 ```

--- a/examples/select_organs.md
+++ b/examples/select_organs.md
@@ -13,7 +13,7 @@
 >>> organs_with_gene = client.select_organs(where='gene', has=['CHN2'], genomic_modality='atac', p_value=0.05)
 >>> assert len(organs_with_gene) > 0
 
->>> organs_with_gene.get_list(1, values_included=['CASTOR2'])[0]['values'].keys()
+>>> organs_with_gene.get_list(values_included=['CASTOR2']).get()[0]['values'].keys()
 dict_keys(['CASTOR2'])
 
 ```

--- a/hubmap_api_py_client/external.py
+++ b/hubmap_api_py_client/external.py
@@ -127,5 +127,4 @@ class ResultsList():
             self.handle, self.output_type, limit,
             offset=offset,
             sort_by=self.sort_by,
-            values_type=self.input_type,
             values_included=self.values_included)

--- a/hubmap_api_py_client/internal.py
+++ b/hubmap_api_py_client/internal.py
@@ -79,7 +79,7 @@ class InternalClient():
 
     def set_detail_evaluation(
             self, set_key: str, set_type: str, limit: int,
-            values_included: List = [], sort_by: str = None, values_type: str = None,
+            values_included: List = [], sort_by: str = None,
             offset: int = 0):
         '''
         This function/API call returns a more detailed version of the set,
@@ -93,8 +93,7 @@ class InternalClient():
             "limit": limit,
             "offset": offset,
             "values_included": values_included,
-            "sort_by": sort_by,
-            "values_type": values_type
+            "sort_by": sort_by
         }
         return self._post_and_get_results(request_url, request_dict)
 


### PR DESCRIPTION
- Calling `get_list()` on a `ResultsSet` returns a `ResultsList`: sort_by and values_included  can be kwargs, but it's not yet evaluated.
- Calling `get()` on a `ResultList` actually hits the API and returns a plain list: offset and limit can be kwargs. This will be replaced with the magic method, but didn't want to change too many things at once.

Perhaps `OrderedResultsSet` would be a better name than `ResultsList`? Other thoughts?