### PR TITLE
notebook test demo

### DIFF
--- a/examples/bounds.ipynb
+++ b/examples/bounds.ipynb
@@ -18,7 +18,7 @@
    "source": [
     "from os import environ\n",
     "from hubmap_api_py_client import Client\n",
-    "api_endpoint = environ.get('API_ENDPOINT', 'https://cells.api.hubmapconsortium.org/api/')\n",
+    "api_endpoint = environ.get('API_ENDPOINT')\n",
     "client = Client(api_endpoint)\n"
    ]
   },

--- a/examples/bounds.ipynb
+++ b/examples/bounds.ipynb
@@ -1,0 +1,76 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# In my IDE, cwd is set to to examples/\n",
+    "%pip install .."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from os import environ\n",
+    "from hubmap_api_py_client import Client\n",
+    "api_endpoint = environ.get('API_ENDPOINT', 'https://cells.api.hubmapconsortium.org/api/')\n",
+    "client = Client(api_endpoint)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "dict_keys(['minimum_value', 'maximum_value'])"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rna_bounds = client.get_bounds('rna')\n",
+    "# These each take > 10s; Is checking just one enough?\n",
+    "# atac_bounds = client.get_bounds('atac')\n",
+    "# codex_bounds = client.get_bounds('codex')\n",
+    "\n",
+    "rna_bounds.keys()"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "40d3a090f54c6569ab1632332b64b2c03c39dcf918b08424e98f38b5ae0af88f"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.7.4 ('base')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.13"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ autopep8==1.5.4
 pytest==6.1.1
 twine==3.2.0
 pytest-xdist==2.2.1
+nbval==0.9.6

--- a/test.sh
+++ b/test.sh
@@ -27,11 +27,19 @@ else
 fi
 end pydoc
 
-start pytest
+start nbtests
+# --nbval does not work with --numprocesses because each cell is evaluated separately.
+# Maybe there's some other way to parallelize tests?
+CMD='API_ENDPOINT="https://cells.api.hubmapconsortium.org/api/" pytest --nbval'
+echo $CMD
+eval $CMD
+end nbtests
+
+start doctests
 CMD='API_ENDPOINT="https://cells.api.hubmapconsortium.org/api/" PYTHONPATH="${PYTHONPATH}:hubmap_api_py_client" pytest --numprocesses auto -vv --doctest-glob="*.md"'
 echo $CMD
 eval $CMD
-end pytest
+end doctests
 
 start changelog
 if [ "$TRAVIS_BRANCH" != 'main' ]; then


### PR DESCRIPTION
@SFD5311 , I've branched from your work in progress and am giving [nbval](https://nbval.readthedocs.io/en/latest/) a test drive.

Plus:
- Perhaps easier to maintain: just edit the notebook, evaluate, and save.
- Prettier: github has nice rendering for notebooks.
- Perhaps easier for users to start exploring on their own: start up jupyter and run the examples.

Minus:
- Notebook files bring in a lot of cruft that plain doctests don't have: diffs harder to read.
- Tests can't be parallelized the same way as before.

Filing as draft:
- Would want to get rid of redundant `bound.md` if this is good.
- Would want to handle all the other tests the same way, probably?
- Can we make it easier for users to run this out of the box? 
  - Maybe `environ.get('API_ENDPOINT', 'https://cells.api.hubmapconsortium.org/api/')`?
  - Maybe `%pip install .. || pip install hubmap-api-py-client`?